### PR TITLE
Bump bell-avr-libraries from 0.1.9 to 0.1.12 in VMC

### DIFF
--- a/VMC/apriltag/python/requirements.txt
+++ b/VMC/apriltag/python/requirements.txt
@@ -1,4 +1,4 @@
 loguru==0.6.0
 numpy==1.23.1
-bell-avr-libraries[mqtt]==0.1.9
+bell-avr-libraries[mqtt]==0.1.12
 transforms3d==0.3.1

--- a/VMC/fcm/requirements.txt
+++ b/VMC/fcm/requirements.txt
@@ -1,6 +1,6 @@
 loguru==0.6.0
 mavsdk==1.4.4
-bell-avr-libraries[mqtt]==0.1.9
+bell-avr-libraries[mqtt]==0.1.12
 bell-avr-pymavlink
 pymap3d
 numpy==1.23.1

--- a/VMC/fusion/requirements.txt
+++ b/VMC/fusion/requirements.txt
@@ -1,4 +1,4 @@
 loguru==0.6.0
 numpy==1.23.1
 pymap3d==3.0.1
-bell-avr-libraries[mqtt]==0.1.9
+bell-avr-libraries[mqtt]==0.1.12

--- a/VMC/pcm/requirements.txt
+++ b/VMC/pcm/requirements.txt
@@ -1,2 +1,2 @@
 loguru==0.6.0
-bell-avr-libraries[mqtt,serial]==0.1.9
+bell-avr-libraries[mqtt,serial]==0.1.12

--- a/VMC/sandbox/requirements.txt
+++ b/VMC/sandbox/requirements.txt
@@ -1,4 +1,4 @@
-bell-avr-libraries[mqtt]==0.1.9
+bell-avr-libraries[mqtt]==0.1.12
 loguru==0.6.0
 opencv-python-headless
 scipy

--- a/VMC/status/requirements.txt
+++ b/VMC/status/requirements.txt
@@ -1,4 +1,4 @@
 loguru==0.6.0
-bell-avr-libraries[mqtt]==0.1.9
+bell-avr-libraries[mqtt]==0.1.12
 adafruit-circuitpython-neopixel-spi==1.0.6
 Jetson.GPIO==2.1.1; sys_platform == 'linux' # implict dependency of adafruit modules

--- a/VMC/thermal/requirements.txt
+++ b/VMC/thermal/requirements.txt
@@ -1,4 +1,4 @@
 loguru==0.6.0
-bell-avr-libraries[mqtt]==0.1.9
+bell-avr-libraries[mqtt]==0.1.12
 adafruit-circuitpython-amg88xx==1.2.15
 Jetson.GPIO==2.1.1; sys_platform == 'linux' # implict dependency of adafruit modules

--- a/VMC/vio/requirements.txt
+++ b/VMC/vio/requirements.txt
@@ -1,4 +1,4 @@
 loguru==0.6.0
 numpy==1.23.1
 transforms3d==0.3.1
-bell-avr-libraries[mqtt]==0.1.9
+bell-avr-libraries[mqtt]==0.1.12


### PR DESCRIPTION
Bring the bell-avr-libraries reqs in the VMC folder up-to-date with the package version in the GUI